### PR TITLE
Handle USB reset

### DIFF
--- a/protocol/lufa/lufa.c
+++ b/protocol/lufa/lufa.c
@@ -176,6 +176,7 @@ void EVENT_USB_Device_Disconnect(void)
 void EVENT_USB_Device_Reset(void)
 {
     print("[R]");
+    USB_IsInitialized = false;
 }
 
 void EVENT_USB_Device_Suspend()


### PR DESCRIPTION
Hi,

I'm running tmk core with on my ErgoDox keyboard using the code from https://github.com/cub-uanic/tmk_keyboard, the repository with my code (and tmk_core cloned to `tmk/core`) can be found here: https://github.com/fd0/ergodox-tmk

Unfortunately I've discovered that tmk core does not seem to handle USB resets, this happens on my hardware for example on boot when switching from grub to the Linux kernel. This patch fixes the behaviour, at least for the LUFA stack.

At least when using the PJRC, USB resets are also not handled. I did not find out how to fix this for PJRC.

Please let me know what you think.
